### PR TITLE
Refactor single byte attribute name serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,6 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
+src/PFire.Console/Logs/
+src/PFire.Console/*.sqlite*

--- a/src/PFire.Core/Protocol/XFireAttributeFactory.cs
+++ b/src/PFire.Core/Protocol/XFireAttributeFactory.cs
@@ -9,9 +9,9 @@ namespace PFire.Core.Protocol
     {
         private static readonly XFireAttributeFactory instance = null;
 
-        private readonly Dictionary<byte, XFireAttribute> _attributeTypes = new Dictionary<byte, XFireAttribute>();
+        private readonly Dictionary<byte, XFireAttribute> _attributeTypes = [];
 
-        private static readonly byte[] IgnoreKnownUnimplementedTypes = {18};
+        private static readonly byte[] IgnoreKnownUnimplementedTypes = [18];
 
         private XFireAttributeFactory()
         {

--- a/src/PFire.Core/Protocol/XMessageField.cs
+++ b/src/PFire.Core/Protocol/XMessageField.cs
@@ -13,11 +13,12 @@ namespace PFire.Core.Protocol
         public XMessageField(string name)
         {
             Name = name;
+            NameAsBytes = Encoding.UTF8.GetBytes(name);
         }
 
         public XMessageField(params byte[] name)
-               //: this(Encoding.UTF8.GetString(name))
         {
+            Name = Encoding.UTF8.GetString(name);
             NonTextualName = true;
             NameAsBytes = name;
         }


### PR DESCRIPTION
This should still serialize and deserialize single byte attribute names, just in a bit of a cleaner way.

Basically, we just always compare the bytes of the attribute instead of the encoded string version, regardless of if it's a single byte attribute, or multiple.